### PR TITLE
Fix apply_patch bwrap failure from stale workspace-write sessions

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.2
+
+- Clarified that Patch compatibility mode's full-access sandbox is applied when a Codex session starts, so a persistent session that began before the mode was enabled (or one changed with `/approvals`) can still hit the `bwrap: Failed to make / slave: Permission denied` error until the add-on is restarted.
+- Added start-up logging that states the effective Codex sandbox mode and reminds you to restart the add-on after changing it.
+- Documented how to recover a session stuck in `workspace-write`: choose Full Access in `/approvals`, or restart the add-on with Patch compatibility mode enabled.
+- Started new sessions with Codex's `--sandbox danger-full-access` flag for the full-access patch path.
+
 ## 1.2.1
 
 - Removed browser-callback sign-in, which cannot reliably return to an isolated Home Assistant add-on container from a user's browser at `localhost`.

--- a/home_assistant_codex_app/README.md
+++ b/home_assistant_codex_app/README.md
@@ -112,6 +112,32 @@ normal patches work without host, Docker, or Supervisor-management access. It
 does not change Codex's command-approval behavior. Disable it only when
 diagnosing a sandbox-related issue.
 
+The sandbox mode is fixed when a Codex session **starts**. Because Session
+persistence keeps one Codex session running in the background, enabling Patch
+compatibility mode only takes effect once a fresh session starts. After changing
+the setting, **restart the HA Codex add-on** (not just navigate away and back).
+
+If `apply_patch` reports:
+
+```text
+apply patch verification failed: Failed to read file to update ...: fs sandbox
+helper failed with status exit status: 1: bwrap: Failed to make / slave:
+Permission denied
+```
+
+then the current Codex session is running in `workspace-write` instead of
+`danger-full-access`, so it is still trying to use Bubblewrap. Recover in one of
+two ways:
+
+- Inside Codex, run `/approvals` (or `/status` to confirm the mode) and choose
+  **Full Access**. This switches the running session immediately.
+- Or restart the HA Codex add-on with Patch compatibility mode enabled, then
+  confirm the session reports `danger-full-access`.
+
+This most often happens when a session that started before Patch compatibility
+mode was enabled is kept alive by Session persistence, or when the mode was
+changed with `/approvals` during the session.
+
 ### Home Assistant control actions
 
 No separate API key, token, IP address, or host setup is needed. To allow

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.1"
+version: "1.2.2"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:

--- a/home_assistant_codex_app/run.sh
+++ b/home_assistant_codex_app/run.sh
@@ -43,7 +43,12 @@ bashio::log.info "Starting HA Codex."
 bashio::log.info "Using Codex model: ${MODEL}."
 bashio::log.info "Terminal history mode: ${TERMINAL_MODE}."
 bashio::log.info "First-time sign-in uses the HA Codex device-code method by default."
-bashio::log.info "Patch compatibility mode: ${PATCH_COMPATIBILITY_MODE}."
+if [ "${PATCH_COMPATIBILITY_MODE}" = "true" ]; then
+  bashio::log.info "Patch compatibility mode: true (new Codex sessions start with sandbox danger-full-access)."
+else
+  bashio::log.info "Patch compatibility mode: false (Codex uses its Bubblewrap sandbox, which apply_patch cannot use on Home Assistant OS)."
+fi
+bashio::log.info "Sandbox mode applies when a Codex session starts; restart the add-on after changing it so a fresh session takes effect."
 bashio::log.info "Home Assistant control actions: ${HOME_ASSISTANT_CONTROL}; Core restart: ${ALLOW_HOME_ASSISTANT_RESTART}."
 
 # ttyd bundles its browser client in its executable.  Extract its matching

--- a/home_assistant_codex_app/session.sh
+++ b/home_assistant_codex_app/session.sh
@@ -56,12 +56,20 @@ fi
 CODEX_ARGS=(--config "${HA_CODEX_CONFIG_OVERRIDE}")
 
 # Home Assistant OS does not allow the nested unprivileged user namespace that
-# Codex's Bubblewrap sandbox needs for apply_patch. The add-on is already the
-# security boundary: it has no host, Docker, or Supervisor-management access.
-# Use that container boundary for normal patches while leaving Codex's command
-# approval policy untouched. The setting remains available for troubleshooting.
+# Codex's Bubblewrap sandbox needs. Without it, apply_patch fails while reading
+# the target file ("bwrap: Failed to make / slave: Permission denied") because
+# its filesystem-verification helper runs under Bubblewrap. The add-on is
+# already the security boundary: it has no host, Docker, or Supervisor-management
+# access. Start Codex in full-access so patches use that container boundary
+# instead of Bubblewrap, while leaving Codex's command approval policy untouched.
+#
+# This applies only to a newly started session. Codex keeps the sandbox mode it
+# launched with, so a session that started before this mode was enabled, or one
+# switched with /approvals, stays in workspace-write until Codex restarts. When
+# that happens, restart the add-on or choose Full Access in /approvals.
+# The setting remains available for troubleshooting.
 if [ "${HA_CODEX_PATCH_COMPATIBILITY_MODE:-true}" = "true" ]; then
-  CODEX_ARGS+=(--config 'sandbox_mode="danger-full-access"')
+  CODEX_ARGS+=(--sandbox danger-full-access)
 fi
 
 CODEX_ARGS+=(--model "${MODEL}")


### PR DESCRIPTION
Fixes #1.

## Problem

On Home Assistant OS, `apply_patch` fails with:

```text
apply patch verification failed: Failed to read file to update /homeassistant/configuration.yaml: fs sandbox helper failed with status exit status: 1: bwrap: Failed to make / slave: Permission denied
```

HA OS restricts the unprivileged namespace operations Bubblewrap (`bwrap`) needs, and Codex routes `apply_patch`'s file read/verify step through that Bubblewrap-based "fs sandbox helper" whenever the session sandbox is `workspace-write`. Running the session in `danger-full-access` bypasses `bwrap` and lets patches apply (see upstream [openai/codex#15678](https://github.com/openai/codex/issues/15678) and [#17969](https://github.com/openai/codex/issues/17969)).

**Patch compatibility mode** already sets `danger-full-access` — but only when a Codex session *starts*, and Codex keeps the mode it launched with for the life of the session. The reporter's session showed `Sandbox mode: workspace-write`: because **Session persistence** keeps one Codex session alive across navigation, a session that started before the mode was in effect — or one changed with `/approvals` — stays in `workspace-write` and keeps hitting the failing Bubblewrap path, even with the toggle reading On. That matches "this happened after some time of HA-CODEX use."

The core recovery is operational (switch the running session to Full Access, or restart the add-on so a fresh session starts in `danger-full-access`). This PR makes that state visible and documented, and hardens the launch path. I deliberately avoided writing a `config.toml` default: it cannot change an already-running session (so it would not fix this case), and a malformed write risks breaking Codex start-up for all users.

## Changes

- **`session.sh`** — start new sessions with the explicit `--sandbox danger-full-access` flag, and clarify in comments that the mode applies only to a freshly started session.
- **`run.sh`** — log the effective Codex sandbox mode at start-up and remind users to restart the add-on after changing it.
- **`README.md`** — add troubleshooting for the exact `bwrap` error, including recovering a running session via `/approvals` → Full Access, or an add-on restart.
- **`config.yaml` / `CHANGELOG.md`** — bump the add-on to 1.2.2 and document the change.

## How to recover an affected session (for users on the current version)

1. In Codex, run `/status` to confirm `workspace-write`, then `/approvals` and choose **Full Access** — this switches the running session immediately; or
2. Restart the HA Codex add-on with Patch compatibility mode enabled, then confirm `/status` reports `danger-full-access`.

## Testing

- `bash -n` passes for `session.sh` and `run.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_