### PR TITLE
Add terminal file transfer (attach/download) via trzsz

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.3
+
+- Added terminal file transfer: run `trz` to attach (upload) a file from your device into the workspace, and `tsz <file>` to download one, using the terminal's built-in `trzsz` support and a browser file picker.
+- Bundled the `trzsz` binaries in the add-on image and documented the attach/download workflow in the README.
+
 ## 1.2.2
 
 - Clarified that Patch compatibility mode's full-access sandbox is applied when a Codex session starts, so a persistent session that began before the mode was enabled (or one changed with `/approvals`) can still hit the `bwrap: Failed to make / slave: Permission denied` error until the add-on is restarted.

--- a/home_assistant_codex_app/Dockerfile
+++ b/home_assistant_codex_app/Dockerfile
@@ -2,13 +2,16 @@ ARG BUILD_FROM
 FROM ${BUILD_FROM}
 
 ARG TTYD_VERSION
+ARG TRZSZ_VERSION
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     TERM=xterm-256color
 
 # Codex itself is installed with OpenAI's Linux installer. ttyd provides the
-# terminal that Home Assistant exposes through Ingress.
+# terminal that Home Assistant exposes through Ingress. trzsz supplies the
+# trz/tsz commands; ttyd's bundled client turns them into a browser file picker
+# so files can be attached to (and downloaded from) the terminal.
 RUN apk add --no-cache \
       bash \
       bubblewrap \
@@ -19,10 +22,17 @@ RUN apk add --no-cache \
       gzip \
       jq \
       ripgrep \
+      tar \
       tmux \
   && update-ca-certificates \
   && curl -fsSL "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64" -o /usr/local/bin/ttyd \
   && chmod 0755 /usr/local/bin/ttyd \
+  && curl -fsSL "https://github.com/trzsz/trzsz-go/releases/download/v${TRZSZ_VERSION}/trzsz_${TRZSZ_VERSION}_linux_x86_64.tar.gz" -o /tmp/trzsz.tar.gz \
+  && mkdir -p /tmp/trzsz \
+  && tar -xzf /tmp/trzsz.tar.gz -C /tmp/trzsz \
+  && find /tmp/trzsz -type f \( -name trz -o -name tsz -o -name trzsz \) -exec install -m 0755 {} /usr/local/bin/ \; \
+  && rm -rf /tmp/trzsz /tmp/trzsz.tar.gz \
+  && trz --version \
   && curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_HOME=/opt/codex CODEX_INSTALL_DIR=/usr/local/bin CODEX_NON_INTERACTIVE=1 sh \
   && codex --version
 

--- a/home_assistant_codex_app/README.md
+++ b/home_assistant_codex_app/README.md
@@ -20,6 +20,7 @@ configuration directory.
 - Review and edit YAML, dashboards, automations, scripts, packages, and custom components.
 - Run local commands such as `git diff`, `rg`, and Home Assistant configuration checks available in the container.
 - Keep a Codex session alive while you leave and return to the Home Assistant sidebar.
+- Attach files from your device with `trz`, and download files back with `tsz`.
 
 It deliberately does **not** request host networking, Docker access, full host
 access, or Supervisor-management API access. Optional Home Assistant control
@@ -153,6 +154,26 @@ the action and request command approval first. The helper cannot control the
 host, Docker, Supervisor, updates, shutdown, or arbitrary Home Assistant
 services. Refresh the browser after dashboard changes; reloading Lovelace
 resources does not reload dashboard YAML or storage configuration by itself.
+
+## Attach files to the terminal
+
+You can move files between your device and the workspace directly in the
+terminal, so Codex can read something you send it (a log, a YAML snippet, a
+screenshot) or hand you a file back. This uses `trzsz`, which the terminal's
+built-in file-transfer support turns into a browser file picker — no extra
+add-on or share is needed.
+
+- **Upload (attach) a file:** run `trz` in the terminal. Your browser opens a
+  file picker; the file is saved into the current directory. Because HA Codex
+  starts in `/homeassistant`, an attached file lands there by default, ready to
+  reference in Codex (for example, "read `error.log` and tell me what's
+  wrong"). To attach into another folder, `cd` there first.
+- **Download a file:** run `tsz <file>` (for example `tsz configuration.yaml`)
+  and your browser downloads it.
+
+This works in the Home Assistant sidebar and with persistent sessions. Very
+large files transfer more slowly over the browser connection; for many files at
+once, attach a `.zip` and unzip it in the terminal.
 
 ## Safe workflow
 

--- a/home_assistant_codex_app/build.yaml
+++ b/home_assistant_codex_app/build.yaml
@@ -2,3 +2,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base:3.22
 args:
   TTYD_VERSION: "1.7.7"
+  TRZSZ_VERSION: "1.2.0"

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.2"
+version: "1.2.3"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:


### PR DESCRIPTION
## Summary

Adds a way to attach files to the terminal (and download them back), so Codex can work with files you send it — a log, a YAML snippet, a screenshot — without a separate file share.

ttyd 1.7.7 already ships trzsz/zmodem file-transfer support in its web client; it only needs the transfer binaries present in the container. This PR bundles `trzsz`, giving two commands in the terminal:

- **`trz`** — opens a browser file picker and saves the upload into the current directory (`/homeassistant` by default), ready for Codex to read.
- **`tsz <file>`** — downloads a file through the browser.

## Changes

- **`Dockerfile` / `build.yaml`** — download and install the `trzsz` binaries, pinned via `TRZSZ_VERSION` (1.2.0), mirroring how `ttyd` is installed; adds a build-time `trz --version` check.
- **`README.md`** — new "Attach files to the terminal" section plus a bullet under "What it can do".
- **`config.yaml` / `CHANGELOG.md`** — bump to 1.2.3.

## Notes

- Chose `trzsz` over `lrzsz`/zmodem: it's the modern option ttyd recommends (progress bar, large files), and downloading the binary from GitHub is the same proven pattern the image already uses for `ttyd`, avoiding a dependency on Alpine packaging.
- Build-time change: it takes effect once a new image is built/released. The Dockerfile install self-checks with `trz --version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_