### PR TITLE
Enable terminal file transfer and make attaching discoverable

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.4
+
+- Enabled ttyd's `trzsz`/zmodem browser file transfer (`enableTrzsz`/`enableZmodem`), which 1.2.3 shipped the binaries for but never turned on — so `trz`/`tsz` now actually open a browser file picker instead of hanging.
+- Added a one-key attach shortcut: press Ctrl-b then u to open an upload picker and drop the file into `/homeassistant` without leaving Codex.
+- Enabled drag-and-drop upload onto a shell prompt, and added a start-up hint showing how to attach and download files.
+- Documented that transfers run from a shell (not the Codex prompt) and that some browsers require HTTPS for the file picker.
+
 ## 1.2.3
 
 - Added terminal file transfer: run `trz` to attach (upload) a file from your device into the workspace, and `tsz <file>` to download one, using the terminal's built-in `trzsz` support and a browser file picker.

--- a/home_assistant_codex_app/README.md
+++ b/home_assistant_codex_app/README.md
@@ -157,23 +157,32 @@ resources does not reload dashboard YAML or storage configuration by itself.
 
 ## Attach files to the terminal
 
-You can move files between your device and the workspace directly in the
-terminal, so Codex can read something you send it (a log, a YAML snippet, a
-screenshot) or hand you a file back. This uses `trzsz`, which the terminal's
-built-in file-transfer support turns into a browser file picker — no extra
-add-on or share is needed.
+You can move files between your device and the workspace, so Codex can read
+something you send it (a log, a YAML snippet, a screenshot) or hand you a file
+back. This uses `trzsz`, which the terminal turns into a browser file picker —
+no extra add-on or share is needed.
 
-- **Upload (attach) a file:** run `trz` in the terminal. Your browser opens a
-  file picker; the file is saved into the current directory. Because HA Codex
-  starts in `/homeassistant`, an attached file lands there by default, ready to
-  reference in Codex (for example, "read `error.log` and tell me what's
-  wrong"). To attach into another folder, `cd` there first.
-- **Download a file:** run `tsz <file>` (for example `tsz configuration.yaml`)
-  and your browser downloads it.
+The terminal normally shows Codex itself, not a shell prompt, so `trz`/`tsz`
+are run from a shell. The quickest way is the built-in shortcut:
 
-This works in the Home Assistant sidebar and with persistent sessions. Very
-large files transfer more slowly over the browser connection; for many files at
-once, attach a `.zip` and unzip it in the terminal.
+- **Attach (upload) a file — the easy way:** press **Ctrl-b** then **u**. A
+  short-lived shell opens and runs `trz` for you, so your browser shows a file
+  picker. The file is saved into `/homeassistant`, and the window returns to
+  Codex when the upload finishes. Then reference it in Codex, for example
+  "read `error.log` and tell me what's wrong".
+- **Attach from a shell yourself:** open a shell tab with **Ctrl-b** then **c**,
+  run `trz`, then return to Codex with **Ctrl-b** then **0**. `cd` first to
+  upload into a different folder. At a shell prompt you can also **drag a file
+  onto the terminal** to start the upload.
+- **Download a file:** in a shell, run `tsz <file>` (for example
+  `tsz configuration.yaml`) and your browser downloads it.
+
+Very large files transfer more slowly over the browser connection; for many
+files at once, attach a `.zip` and unzip it in the terminal.
+
+If the file picker never appears, your browser may be blocking file dialogs on
+an insecure origin — open Home Assistant over HTTPS (for example through Nabu
+Casa remote access) and try again.
 
 ## Safe workflow
 

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.3"
+version: "1.2.4"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:

--- a/home_assistant_codex_app/run.sh
+++ b/home_assistant_codex_app/run.sh
@@ -72,6 +72,10 @@ else
   bashio::log.warning "Could not locate ttyd's browser client; using ttyd's standard page."
 fi
 
+# enableZmodem/enableTrzsz turn on ttyd's browser-side file transfer; without
+# them the installed trz/tsz binaries never receive the client handshake, so an
+# upload just hangs. trzszDragInitTimeout allows dragging a file onto the
+# terminal to start an upload.
 exec /usr/local/bin/ttyd \
   --writable \
   --port 7681 \
@@ -79,5 +83,8 @@ exec /usr/local/bin/ttyd \
   --client-option "fontSize=${FONT_SIZE}" \
   --client-option "scrollback=${SCROLLBACK}" \
   --client-option "theme=${THEME}" \
+  --client-option "enableZmodem=true" \
+  --client-option "enableTrzsz=true" \
+  --client-option "trzszDragInitTimeout=5000" \
   "${TTYD_INDEX_ARGS[@]}" \
   bash -lc "${COMMAND}"

--- a/home_assistant_codex_app/session.sh
+++ b/home_assistant_codex_app/session.sh
@@ -53,6 +53,14 @@ if ! codex login status >/dev/null 2>&1; then
   done
 fi
 
+# Remind users how to move files in and out of the terminal. Printed once before
+# Codex starts; in inline mode it stays visible in the scrollback above Codex.
+if [ -n "${TMUX:-}" ]; then
+  printf '%s\n\n' 'Attach a file: press Ctrl-b then u for an upload picker (or run "trz" in a shell). Download: "tsz <file>". You can also drag a file onto a shell prompt.'
+else
+  printf '%s\n\n' 'Attach a file: run "trz" in the shell to upload; "tsz <file>" to download. You can also drag a file onto the shell prompt.'
+fi
+
 CODEX_ARGS=(--config "${HA_CODEX_CONFIG_OVERRIDE}")
 
 # Home Assistant OS does not allow the nested unprivileged user namespace that

--- a/home_assistant_codex_app/tmux.conf
+++ b/home_assistant_codex_app/tmux.conf
@@ -4,3 +4,8 @@
 set -g mouse on
 set -g alternate-screen off
 set -as terminal-overrides ',xterm*:smcup@:rmcup@'
+
+# One-key file attach: prefix (Ctrl-b) then u opens a shell in the config
+# directory and runs trz, so the browser shows an upload picker without leaving
+# the Codex session. The window closes and returns to Codex when done.
+bind-key u new-window -c /homeassistant -n attach 'trz; printf "\nUpload finished. Press Enter to return to Codex."; read _'


### PR DESCRIPTION
## Summary

Fixes the file-attach feature from 1.2.3 and makes it easy to use.

1.2.3 installed the `trzsz` binaries but never enabled ttyd's browser-side file transfer, which ttyd keeps off unless launched with `enableTrzsz`/`enableZmodem`. So `trz`/`tsz` had no client handshake and an upload would just hang — the feature didn't actually work.

## Changes

- **`run.sh`** — pass ttyd `--client-option enableZmodem=true`, `enableTrzsz=true`, and `trzszDragInitTimeout=5000`, so `trz`/`tsz` open a browser file picker and drag-and-drop uploads work.
- **`tmux.conf`** — one-key attach shortcut: **Ctrl-b** then **u** opens a shell in `/homeassistant`, runs `trz`, and returns to Codex when done.
- **`session.sh`** — print a start-up hint showing how to attach/download files (tmux vs non-tmux variants).
- **`README.md`** — explain transfers run from a shell (not the Codex prompt), document the shortcut, drag-and-drop, and the HTTPS/secure-context caveat some browsers impose on file dialogs.
- **`config.yaml` / `CHANGELOG.md`** — bump to 1.2.4.

## Notes

- Build/runtime change; verified `run.sh` and `session.sh` with `bash -n` and parsed `tmux.conf` cleanly. The live browser picker / drag-and-drop couldn't be click-tested in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_