### PR TITLE
Bump base image to Alpine 3.23 and pin Codex version

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.6
+
+- Updated the add-on base image from Alpine 3.22 to 3.23.
+- Pinned Codex to a specific release (0.152.0) instead of always installing the latest, so a future Codex change cannot silently alter the add-on's behavior. Bump `CODEX_VERSION` in `build.yaml` to update Codex.
+
 ## 1.2.5
 
 - Fixed pasting long text, which 1.2.4 broke by enabling trzsz: its browser client routes terminal input through a paste/drag handler that mangles large pastes.

--- a/home_assistant_codex_app/Dockerfile
+++ b/home_assistant_codex_app/Dockerfile
@@ -3,15 +3,18 @@ FROM ${BUILD_FROM}
 
 ARG TTYD_VERSION
 ARG TRZSZ_VERSION
+ARG CODEX_VERSION
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     TERM=xterm-256color
 
-# Codex itself is installed with OpenAI's Linux installer. ttyd provides the
-# terminal that Home Assistant exposes through Ingress. trzsz supplies the
-# trz/tsz commands; ttyd's bundled client turns them into a browser file picker
-# so files can be attached to (and downloaded from) the terminal.
+# Codex is installed from a pinned GitHub release (CODEX_VERSION) rather than the
+# always-latest installer, so a new Codex release cannot change the add-on's
+# behavior until the pin is bumped. ttyd provides the terminal that Home
+# Assistant exposes through Ingress. trzsz supplies the trz/tsz commands; ttyd's
+# bundled client turns them into a browser file picker so files can be attached
+# to (and downloaded from) the terminal.
 RUN apk add --no-cache \
       bash \
       bubblewrap \
@@ -33,7 +36,11 @@ RUN apk add --no-cache \
   && find /tmp/trzsz -type f \( -name trz -o -name tsz -o -name trzsz \) -exec install -m 0755 {} /usr/local/bin/ \; \
   && rm -rf /tmp/trzsz /tmp/trzsz.tar.gz \
   && trz --version \
-  && curl -fsSL https://chatgpt.com/codex/install.sh | CODEX_HOME=/opt/codex CODEX_INSTALL_DIR=/usr/local/bin CODEX_NON_INTERACTIVE=1 sh \
+  && curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-x86_64-unknown-linux-musl.tar.gz" -o /tmp/codex.tar.gz \
+  && mkdir -p /tmp/codex \
+  && tar -xzf /tmp/codex.tar.gz -C /tmp/codex \
+  && install -m 0755 "$(find /tmp/codex -type f -name 'codex*' ! -name '*.sigstore' | head -n 1)" /usr/local/bin/codex \
+  && rm -rf /tmp/codex /tmp/codex.tar.gz \
   && codex --version
 
 COPY run.sh /run.sh
@@ -41,7 +48,7 @@ COPY session.sh /usr/local/bin/ha-codex-session
 COPY ha-codex-ha /usr/local/bin/ha-codex-ha
 COPY tmux.conf /etc/ha-codex-tmux.conf
 RUN chmod 0755 /run.sh /usr/local/bin/ha-codex-session /usr/local/bin/ha-codex-ha \
-  && mkdir -p /homeassistant /config/codex /opt/codex
+  && mkdir -p /homeassistant /config/codex
 
 WORKDIR /homeassistant
 

--- a/home_assistant_codex_app/build.yaml
+++ b/home_assistant_codex_app/build.yaml
@@ -1,5 +1,6 @@
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-base:3.22
+  amd64: ghcr.io/home-assistant/amd64-base:3.23
 args:
   TTYD_VERSION: "1.7.7"
   TRZSZ_VERSION: "1.2.0"
+  CODEX_VERSION: "0.152.0"

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.5"
+version: "1.2.6"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:


### PR DESCRIPTION
## Summary

Dependency maintenance: move to the current Alpine base and stop tracking Codex "latest" so a Codex release can't silently change add-on behavior.

## Changes

- **`build.yaml`** — base image `amd64-base:3.22` → **`3.23`** (rolling tag, keeps Alpine patch updates); add `CODEX_VERSION: "0.152.0"`.
- **`Dockerfile`** — install Codex from a pinned GitHub release (`rust-v${CODEX_VERSION}`, `codex-x86_64-unknown-linux-musl`) instead of the always-latest installer; the final `codex --version` fails the build if the asset can't be resolved. Removed the now-unused `/opt/codex` build directory.
- **`config.yaml` / `CHANGELOG.md`** — bump to 1.2.6.

ttyd (1.7.7) and trzsz (1.2.0) are already at their latest releases, so they're unchanged. To update Codex in future, bump `CODEX_VERSION`.

## Testing / caveats

These are build-time changes that can't be executed in the authoring environment. They're verified when the add-on image builds:
- The rolling `3.23` base tag (fallback: `3.23-2026.02.0`).
- The Codex musl asset download + `codex --version` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_