### PR TITLE
docs: add release version badge and link the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ allowlisted helper.
 ## Install
 
 [![Add HA Codex repository to Home Assistant](https://my.home-assistant.io/badges/supervisor.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fambient-home-systems%2Fha-codex)
+[![Latest release](https://img.shields.io/github/v/release/ambient-home-systems/ha-codex?label=version&sort=semver)](https://github.com/ambient-home-systems/ha-codex/releases/latest)
 
 1. Select the button above to open your Home Assistant instance with the HA
    Codex repository URL pre-filled, then add the repository.
@@ -216,7 +217,7 @@ normal Codex operation is not blocked by the fallback sandbox message.
 Every release has three matching records:
 
 - The add-on version in `home_assistant_codex_app/config.yaml`.
-- User-facing Home Assistant update notes in `home_assistant_codex_app/CHANGELOG.md`.
+- User-facing Home Assistant update notes in the [changelog](home_assistant_codex_app/CHANGELOG.md).
 - A tagged [GitHub Release](https://github.com/ambient-home-systems/ha-codex/releases).
 
 Use the App Store to install updates. Open the update details before

--- a/home_assistant_codex_app/README.md
+++ b/home_assistant_codex_app/README.md
@@ -29,6 +29,7 @@ uses the supported internal Core API through a restricted helper.
 ## Install
 
 [![Add HA Codex repository to Home Assistant](https://my.home-assistant.io/badges/supervisor.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fambient-home-systems%2Fha-codex)
+[![Latest release](https://img.shields.io/github/v/release/ambient-home-systems/ha-codex?label=version&sort=semver)](https://github.com/ambient-home-systems/ha-codex/releases/latest)
 
 1. Select the button above to open your Home Assistant instance with the HA
    Codex repository URL pre-filled, then add the repository.
@@ -42,6 +43,8 @@ and use its repository-management option to add:
 ```text
 https://github.com/ambient-home-systems/ha-codex
 ```
+
+See the [changelog](CHANGELOG.md) for what changed in each release.
 
 ## First sign-in
 


### PR DESCRIPTION
## Summary

Docs-only update to the READMEs.

- Add a shields.io **Latest release** (version) badge next to the "Add repository" install badge in both the root and add-on READMEs; it reads the newest release tag and links to the Releases page.
- Turn the plain `CHANGELOG.md` reference into a link in the root README, and add a changelog link to the add-on README.

No version bump — this changes documentation only and needs no rebuild or release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_