### PR TITLE
Release HA Codex 1.2.7

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.7
+
+- Added a latest-release version badge to the READMEs and linked the changelog from both. Documentation only; no functional changes.
+
 ## 1.2.6
 
 - Updated the add-on base image from Alpine 3.22 to 3.23.

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.6"
+version: "1.2.7"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:


### PR DESCRIPTION
## Summary

Version bump to ship the README release badge and changelog links (merged in #7) as a tagged release.

- **`config.yaml`** — bump to 1.2.7.
- **`CHANGELOG.md`** — add the 1.2.7 entry.

Documentation only; no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3c71sEpCHn2unnVrq4voN)_