### PR TITLE
Fix Codex 0.152.0 runtime dependencies

### DIFF
--- a/.github/workflows/validate-addon-amd64.yml
+++ b/.github/workflows/validate-addon-amd64.yml
@@ -82,7 +82,7 @@ jobs:
 
           test "$(docker inspect ha-codex-runtime-smoke --format '{{.State.Health.Status}}')" = "healthy"
           docker logs ha-codex-runtime-smoke
-          test -x /run.sh
+          docker run --rm --entrypoint /bin/sh "$image" -ec 'test -x /run.sh'
 
       - name: Clean up runtime container
         if: always()

--- a/.github/workflows/validate-addon-amd64.yml
+++ b/.github/workflows/validate-addon-amd64.yml
@@ -1,0 +1,89 @@
+name: HA Codex amd64 image validation
+
+on:
+  pull_request:
+    paths:
+      - "home_assistant_codex_app/**"
+      - ".github/workflows/validate-addon-amd64.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke-test:
+    name: Build and smoke-test amd64 add-on
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build pinned amd64 add-on image
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            --build-arg BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.23 \
+            --build-arg TTYD_VERSION=1.7.7 \
+            --build-arg TRZSZ_VERSION=1.2.0 \
+            --build-arg CODEX_VERSION=0.152.0 \
+            --tag ha-codex:pr-${{ github.event.pull_request.number || github.run_id }} \
+            home_assistant_codex_app
+
+      - name: Verify runtime dependencies
+        run: |
+          image="ha-codex:pr-${{ github.event.pull_request.number || github.run_id }}"
+          docker run --rm --entrypoint /bin/sh "$image" -ec '
+            command -v codex
+            test -x /usr/local/bin/codex
+            test "$(codex --version)" = "codex-cli 0.152.0"
+            command -v codex-code-mode-host
+            test -x /usr/local/bin/codex-code-mode-host
+            codex-code-mode-host --help
+            command -v node
+            node --version
+            if command -v npm >/dev/null 2>&1; then
+              echo "npm must not be installed" >&2
+              exit 1
+            fi
+          '
+
+      - name: Verify image metadata
+        run: |
+          image="ha-codex:pr-${{ github.event.pull_request.number || github.run_id }}"
+          test "$(docker image inspect "$image" --format '{{.Config.WorkingDir}}')" = "/homeassistant"
+          test "$(docker image inspect "$image" --format '{{json .Config.Cmd}}')" = '["/run.sh"]'
+          docker image inspect "$image" --format '{{json .Config.Healthcheck.Test}}' |
+            grep -F 'http://127.0.0.1:7681/'
+
+      - name: Start add-on entry point and wait for health check
+        run: |
+          image="ha-codex:pr-${{ github.event.pull_request.number || github.run_id }}"
+          options_file="$RUNNER_TEMP/ha-codex-options.json"
+          printf '%s\n' '{"model":"gpt-5.6-terra","terminal_font_size":14,"terminal_scrollback":5000,"terminal_theme":"dark","session_persistence":true,"preserve_terminal_history":true,"patch_compatibility_mode":true,"file_transfer":false,"home_assistant_control":false,"allow_home_assistant_restart":false}' > "$options_file"
+
+          docker run --detach \
+            --name ha-codex-runtime-smoke \
+            --volume "$options_file:/data/options.json:ro" \
+            "$image"
+
+          for attempt in $(seq 1 24); do
+            status="$(docker inspect ha-codex-runtime-smoke --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}')"
+            if [ "$status" = "healthy" ]; then
+              break
+            fi
+            if [ "$status" = "unhealthy" ] || [ "$(docker inspect ha-codex-runtime-smoke --format '{{.State.Running}}')" != "true" ]; then
+              docker logs ha-codex-runtime-smoke
+              exit 1
+            fi
+            sleep 5
+          done
+
+          test "$(docker inspect ha-codex-runtime-smoke --format '{{.State.Health.Status}}')" = "healthy"
+          docker logs ha-codex-runtime-smoke
+          test -x /run.sh
+
+      - name: Clean up runtime container
+        if: always()
+        run: docker rm --force ha-codex-runtime-smoke 2>/dev/null || true

--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.8
+
+- Included the version-matched `codex-code-mode-host`, fixing local workspace and image-inspection tools that failed because the host executable was absent.
+- Added Node.js so Node-based plugin MCP servers, including `dataAnalyticsWidgets`, can start. npm is not installed because these servers use the bundled runtime files directly.
+- Cloudflare MCP authentication remains a separate, optional, user-configured action; HA Codex does not authenticate it automatically.
+
 ## 1.2.7
 
 - Added a latest-release version badge to the READMEs and linked the changelog from both. Documentation only; no functional changes.

--- a/home_assistant_codex_app/Dockerfile
+++ b/home_assistant_codex_app/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache \
       grep \
       gzip \
       jq \
+      nodejs \
       ripgrep \
       tar \
       tmux \
@@ -41,7 +42,20 @@ RUN apk add --no-cache \
   && tar -xzf /tmp/codex.tar.gz -C /tmp/codex \
   && install -m 0755 "$(find /tmp/codex -type f -name 'codex*' ! -name '*.sigstore' | head -n 1)" /usr/local/bin/codex \
   && rm -rf /tmp/codex /tmp/codex.tar.gz \
-  && codex --version
+  && curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz" -o /tmp/codex-code-mode-host.tar.gz \
+  && mkdir -p /tmp/codex-code-mode-host \
+  && tar -xzf /tmp/codex-code-mode-host.tar.gz -C /tmp/codex-code-mode-host \
+  && set -- $(find /tmp/codex-code-mode-host -type f -perm /111 -name 'codex-code-mode-host*' \
+      ! -name '*.sigstore' ! -name '*.sha256' ! -name '*.checksum'); \
+     [ "$#" -eq 1 ] \
+  && install -m 0755 "$1" /usr/local/bin/codex-code-mode-host \
+  && rm -rf /tmp/codex-code-mode-host /tmp/codex-code-mode-host.tar.gz \
+  && codex --version \
+  && command -v codex-code-mode-host \
+  && test -x /usr/local/bin/codex-code-mode-host \
+  && codex-code-mode-host --help \
+  && command -v node \
+  && node --version
 
 COPY run.sh /run.sh
 COPY session.sh /usr/local/bin/ha-codex-session

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.7"
+version: "1.2.8"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:


### PR DESCRIPTION
## Root cause

Codex CLI 0.152.0 introduced two runtime requirements that the 1.2.7 Alpine image does not provide:

- Code Mode launches a separately distributed, version-matched `codex-code-mode-host`; the image only installed `codex`.
- The Data Analytics plugin launches its bundled MCP server with `node ./mcp/server.cjs --stdio`; the image did not contain the `node` executable.

Cloudflare MCP authentication is unrelated and remains an optional user-configured action.

## Files changed

- `home_assistant_codex_app/Dockerfile`
  - adds Alpine `nodejs` (not npm)
  - downloads the Code Mode host from the same `rust-v${CODEX_VERSION}` release as Codex
  - discovers executable candidates after extraction and fails unless exactly one suitable host is found
  - installs it as `/usr/local/bin/codex-code-mode-host`
  - runs the requested Codex, host, and Node build-time checks
- `home_assistant_codex_app/config.yaml`: bumps 1.2.7 to 1.2.8
- `home_assistant_codex_app/CHANGELOG.md`: documents the runtime fixes and Cloudflare boundary

## Validation completed before PR

- Live archive inspected for `rust-v0.152.0`; it contains one executable named `codex-code-mode-host-x86_64-unknown-linux-musl`.
- That extracted binary ran `--help` noninteractively, printed usage, and exited 0, so `--help` is retained as the build smoke test.
- `git diff --check`: passed.
- Final branch comparison: one commit, three files, no unrelated changes.
- `config.yaml`: 1.2.8.
- `build.yaml`: `CODEX_VERSION: "0.152.0"`, unchanged.
- `run.sh`, default model, model selector, working directory, entry point, health check, permissions, ports, and persistent-data behavior: unchanged.
- Diff secret scan: no OAuth/GitHub tokens, API keys, Cloudflare credentials, or private keys found.
- npm was not added.

## Release gate

The repository has no checked-in GitHub Actions workflows, and the current execution environment has no Docker/Podman engine. Therefore an amd64 image build and fresh-container runtime validation have **not** yet been claimed. Do not merge or release until the repository's normal external/Home Assistant build path completes the required image and runtime checks.