### PR TITLE
Update model catalog for HA Codex 1.2.9

### DIFF
--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.9
+
+- Added `gpt-6-astra` to the model selector. Availability depends on the user's ChatGPT plan, workspace settings, and rollout eligibility.
+- Removed `gpt-5.4` and `gpt-5.4-mini` from the selector because they retired from Codex with ChatGPT sign-in; use `gpt-5.6-terra` and `gpt-5.6-luna` respectively.
+- Kept `gpt-5.6-terra` as the default model for broad compatibility.
+
 ## 1.2.8
 
 - Included the version-matched `codex-code-mode-host`, fixing local workspace and image-inspection tools that failed because the host executable was absent.

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.8"
+version: "1.2.9"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:
@@ -33,7 +33,7 @@ options:
   home_assistant_control: false
   allow_home_assistant_restart: false
 schema:
-  model: list(gpt-5.6-terra|gpt-5.6-sol|gpt-5.6-luna|gpt-5.6|gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.3-codex-spark)
+  model: list(gpt-6-astra|gpt-5.6-terra|gpt-5.6-sol|gpt-5.6-luna|gpt-5.6|gpt-5.5|gpt-5.3-codex-spark)
   terminal_font_size: int(10,24)
   terminal_scrollback: int(1000,50000)
   terminal_theme: list(dark|light)


### PR DESCRIPTION
## Summary

Update the HA Codex model catalog for version 1.2.9.

- Add `gpt-6-astra` to the selectable models.
- Remove retired `gpt-5.4` and `gpt-5.4-mini` choices for ChatGPT-sign-in users.
- Keep `gpt-5.6-terra` as the default.
- Document that Astra availability depends on plan, workspace settings, and rollout eligibility.

## Compatibility

- Codex CLI remains pinned to `0.152.0`.
- No container dependencies, permissions, ports, entry points, Home Assistant controls, or persistent data paths are changed.
- Existing users whose saved configuration selects a retired model should select Terra or Luna before starting 1.2.9.

Official model catalog: https://learn.chatgpt.com/docs/models