### PR TITLE
Update Codex CLI to 0.153.4

### DIFF
--- a/.github/workflows/validate-addon-amd64.yml
+++ b/.github/workflows/validate-addon-amd64.yml
@@ -24,15 +24,21 @@ jobs:
         id: build_config
         run: |
           build_file="home_assistant_codex_app/build.yaml"
-          echo "build_from=$(sed -n 's/^  amd64: //p' "$build_file")" >> "$GITHUB_OUTPUT"
-          echo "ttyd_version=$(sed -n 's/^  TTYD_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
-          echo "trzsz_version=$(sed -n 's/^  TRZSZ_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
-          echo "codex_version=$(sed -n 's/^  CODEX_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
+          build_from="$(awk '$1 == "amd64:" {print $2}' "$build_file")"
+          ttyd_version="$(awk '$1 == "TTYD_VERSION:" {gsub(/"/, "", $2); print $2}' "$build_file")"
+          trzsz_version="$(awk '$1 == "TRZSZ_VERSION:" {gsub(/"/, "", $2); print $2}' "$build_file")"
+          codex_version="$(awk '$1 == "CODEX_VERSION:" {gsub(/"/, "", $2); print $2}' "$build_file")"
 
-          test -n "$(sed -n 's/^  amd64: //p' "$build_file")"
-          test -n "$(sed -n 's/^  TTYD_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
-          test -n "$(sed -n 's/^  TRZSZ_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
-          test -n "$(sed -n 's/^  CODEX_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
+          for value in "$build_from" "$ttyd_version" "$trzsz_version" "$codex_version"; do
+            test -n "$value"
+          done
+
+          {
+            echo "build_from=$build_from"
+            echo "ttyd_version=$ttyd_version"
+            echo "trzsz_version=$trzsz_version"
+            echo "codex_version=$codex_version"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build pinned amd64 add-on image
         run: |
@@ -50,7 +56,7 @@ jobs:
           EXPECTED_CODEX_VERSION: ${{ steps.build_config.outputs.codex_version }}
         run: |
           image="ha-codex:pr-${{ github.event.pull_request.number || github.run_id }}"
-          docker run --rm --entrypoint /bin/sh "$image" -ec '
+          docker run --rm --env EXPECTED_CODEX_VERSION --entrypoint /bin/sh "$image" -ec '
             command -v codex
             test -x /usr/local/bin/codex
             test "$(codex --version)" = "codex-cli ${EXPECTED_CODEX_VERSION}"

--- a/.github/workflows/validate-addon-amd64.yml
+++ b/.github/workflows/validate-addon-amd64.yml
@@ -20,24 +20,40 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Read pinned build configuration
+        id: build_config
+        run: |
+          build_file="home_assistant_codex_app/build.yaml"
+          echo "build_from=$(sed -n 's/^  amd64: //p' "$build_file")" >> "$GITHUB_OUTPUT"
+          echo "ttyd_version=$(sed -n 's/^  TTYD_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
+          echo "trzsz_version=$(sed -n 's/^  TRZSZ_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
+          echo "codex_version=$(sed -n 's/^  CODEX_VERSION: "\\(.*\\)"/\\1/p' "$build_file")" >> "$GITHUB_OUTPUT"
+
+          test -n "$(sed -n 's/^  amd64: //p' "$build_file")"
+          test -n "$(sed -n 's/^  TTYD_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
+          test -n "$(sed -n 's/^  TRZSZ_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
+          test -n "$(sed -n 's/^  CODEX_VERSION: "\\(.*\\)"/\\1/p' "$build_file")"
+
       - name: Build pinned amd64 add-on image
         run: |
           docker build \
             --platform linux/amd64 \
-            --build-arg BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.23 \
-            --build-arg TTYD_VERSION=1.7.7 \
-            --build-arg TRZSZ_VERSION=1.2.0 \
-            --build-arg CODEX_VERSION=0.152.0 \
+            --build-arg BUILD_FROM=${{ steps.build_config.outputs.build_from }} \
+            --build-arg TTYD_VERSION=${{ steps.build_config.outputs.ttyd_version }} \
+            --build-arg TRZSZ_VERSION=${{ steps.build_config.outputs.trzsz_version }} \
+            --build-arg CODEX_VERSION=${{ steps.build_config.outputs.codex_version }} \
             --tag ha-codex:pr-${{ github.event.pull_request.number || github.run_id }} \
             home_assistant_codex_app
 
       - name: Verify runtime dependencies
+        env:
+          EXPECTED_CODEX_VERSION: ${{ steps.build_config.outputs.codex_version }}
         run: |
           image="ha-codex:pr-${{ github.event.pull_request.number || github.run_id }}"
           docker run --rm --entrypoint /bin/sh "$image" -ec '
             command -v codex
             test -x /usr/local/bin/codex
-            test "$(codex --version)" = "codex-cli 0.152.0"
+            test "$(codex --version)" = "codex-cli ${EXPECTED_CODEX_VERSION}"
             command -v codex-code-mode-host
             test -x /usr/local/bin/codex-code-mode-host
             codex-code-mode-host --help

--- a/home_assistant_codex_app/CHANGELOG.md
+++ b/home_assistant_codex_app/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to HA Codex are documented here.
 
+## 1.2.10
+
+- Updated the pinned Codex CLI from 0.152.0 to 0.153.4, including the version-matched `codex-code-mode-host` artifact.
+- Included Codex's Astra model-picker visibility fix and updated Astra tool guidance while keeping `gpt-5.6-terra` as the HA Codex default.
+- Updated amd64 validation to read its image base and dependency versions directly from `build.yaml`, preventing the test workflow from drifting from the release pin.
+
 ## 1.2.9
 
 - Added `gpt-6-astra` to the model selector. Availability depends on the user's ChatGPT plan, workspace settings, and rollout eligibility.

--- a/home_assistant_codex_app/build.yaml
+++ b/home_assistant_codex_app/build.yaml
@@ -3,4 +3,4 @@ build_from:
 args:
   TTYD_VERSION: "1.7.7"
   TRZSZ_VERSION: "1.2.0"
-  CODEX_VERSION: "0.152.0"
+  CODEX_VERSION: "0.153.4"

--- a/home_assistant_codex_app/config.yaml
+++ b/home_assistant_codex_app/config.yaml
@@ -1,6 +1,6 @@
 name: HA Codex
 description: Before starting, select the Codex model in App Configuration. Patch compatibility mode is enabled by default so Codex can use normal patches on Home Assistant OS. To let Codex validate, reload, or restart Home Assistant, enable "Allow Home Assistant control actions" (and separately "Allow Home Assistant Core restart"), then restart this add-on.
-version: "1.2.9"
+version: "1.2.10"
 slug: home_assistant_codex_app
 url: https://github.com/ambient-home-systems/ha-codex
 arch:


### PR DESCRIPTION
## Summary

Update HA Codex to Codex CLI 0.153.4.

- Bump `CODEX_VERSION` from 0.152.0 to 0.153.4.
- Keep downloading the version-matched `codex-code-mode-host` from the same release.
- Include the 0.153.4 Astra model-picker visibility and guidance fixes.
- Bump the add-on version to 1.2.10.
- Update amd64 CI validation to read all build arguments from `home_assistant_codex_app/build.yaml`, so the release pin and validation cannot drift apart.

## Compatibility and validation

- HA Codex continues to default to `gpt-5.6-terra`.
- Existing security, permissions, ports, entry point, working directory, and persistent data behavior are unchanged.
- The complete amd64 image and runtime validation will run before merge.